### PR TITLE
Update vim-surround macros with recipes to handle "\<CR>" input.

### DIFF
--- a/macros/sandwich/keymap/surround.vim
+++ b/macros/sandwich/keymap/surround.vim
@@ -25,6 +25,21 @@ endif
 " Default recipes
 let g:sandwich#recipes = [
       \   {
+      \     'buns':         ['', ''],
+      \     'action':       ['add'],
+      \     'motionwise':   ['line'],
+      \     'linewise':     1,
+      \     'input':        ["\<CR>"]
+      \   },
+      \
+      \   {
+      \     'buns':         ['^$', '^$'],
+      \     'regex':        1,
+      \     'linewise':     1,
+      \     'input':        ["\<CR>"]
+      \   },
+      \
+      \   {
       \     'buns':         ['<', '>'],
       \     'expand_range': 0,
       \     'match_syntax': 1,


### PR DESCRIPTION
Maybe it worth to add these new receipes to macros too?