### PR TITLE
Fallback imsearch to 0 on tag prompting

### DIFF
--- a/autoload/sandwich/magicchar/t.vim
+++ b/autoload/sandwich/magicchar/t.vim
@@ -10,7 +10,10 @@ let s:type_list = type([])
 function! sandwich#magicchar#t#tag() abort "{{{
   call operator#sandwich#show()
   echohl MoreMsg
+  let old_imsearch = &l:imsearch
+  let &l:imsearch = 0
   let tag = input('Input tag: ')
+  let &l:imsearch = old_imsearch
   echohl NONE
   call operator#sandwich#quench()
   if tag ==# ''
@@ -23,7 +26,10 @@ endfunction
 function! sandwich#magicchar#t#tagname() abort "{{{
   call operator#sandwich#show()
   echohl MoreMsg
+  let old_imsearch = &l:imsearch
+  let &l:imsearch = 0
   let tagname = input('Input tag name: ')
+  let &l:imsearch = old_imsearch
   echohl NONE
   call operator#sandwich#quench()
   if tagname ==# ''


### PR DESCRIPTION
Hi!
The proposed fix can be handy if you have `set keymap=` something other than default empty string. The `set keymap=something` is very useful to work with text of languages other than English, as it keeps all your keymaps working in normal mode, while you instantly can input text in that other language.

I've faced a drawback of this approach while using it with vim-sandwich on my xml files.
The point is, `set keymap=something` affects `imsearch` option (which is great itself and let you search text with native language) and somehow vim-sandwich prompt for adding/changing tag name. Sure, it is possible to change the layout by <kbd>Ctrl-^</kbd>, but the workflow gets not so smooth, IMO.

Maybe you will be convinced by the arguments and decide to merge. If so, please feel free to polish the code on your taste and request any additional info on the topic.

P.S. vim-sandwich is a swiss army knife, thank you for it again!
