### PR TITLE
Add backtick (`) to default_recipes

### DIFF
--- a/autoload/sandwich.vim
+++ b/autoload/sandwich.vim
@@ -20,6 +20,7 @@ let g:sandwich#default_recipes = [
       \   {'buns': ['<', '>'], 'expand_range': 0, 'match_syntax': 1},
       \   {'buns': ['"', '"'], 'quoteescape': 1, 'expand_range': 0, 'nesting': 0, 'linewise': 0},
       \   {'buns': ["'", "'"], 'quoteescape': 1, 'expand_range': 0, 'nesting': 0, 'linewise': 0},
+      \   {'buns': ["`", "`"], 'quoteescape': 1, 'expand_range': 0, 'nesting': 0, 'linewise': 0},
       \   {'buns': ['{', '}'], 'nesting': 1, 'match_syntax': 1, 'skip_break': 1},
       \   {'buns': ['[', ']'], 'nesting': 1, 'match_syntax': 1},
       \   {'buns': ['(', ')'], 'nesting': 1, 'match_syntax': 1},


### PR DESCRIPTION
I think the backtick (`) should be on the default recipes, since they are frequently used in languages like javascript or bash. I thought I would offer the suggestion with this PR, but feel free to reject it if doesn't make sense to you.

Thanks for `sandwich.vim` it's really a great plugin.