### PR TITLE
Add new JSX Filetypes

### DIFF
--- a/autoload/sandwich.vim
+++ b/autoload/sandwich.vim
@@ -42,7 +42,9 @@ lockvar! g:sandwich#default_recipes
 
 let g:sandwich#jsx_filetypes = [
       \ 'javascript.jsx',
-      \ 'typescript.tsx'
+      \ 'typescript.tsx',
+      \ 'javascriptreact',
+      \ 'typescriptreact'
       \ ]
 
 " vim:set foldmethod=marker:


### PR DESCRIPTION
Vim added new filetypes for JSX (vim/vim@92852cee3fcff1dc6ce12387b234634e73267b22), so I've updated the plugin to use them.

Kept the old filetypes to avoid breaking changes to the plugin.