### PR TITLE
Use buffer-specific options before global in magicchar-f

### DIFF
--- a/autoload/sandwich/magicchar/f.vim
+++ b/autoload/sandwich/magicchar/f.vim
@@ -319,8 +319,8 @@ function! s:is_continuous_syntax(bra_pos, ket_pos) abort  "{{{
 endfunction
 "}}}
 function! s:resolve_patterns() abort  "{{{
-  return deepcopy(get(g:, 'sandwich#magicchar#f#patterns',
-                \ get(b:, 'sandwich_magicchar_f_patterns',
+  return deepcopy(get(b:, 'sandwich_magicchar_f_patterns',
+                \ get(g:, 'sandwich#magicchar#f#patterns',
                 \ g:sandwich#magicchar#f#default_patterns)))
 endfunction
 "}}}


### PR DESCRIPTION
If a user defines `g:sandwich#magicchar#f#patterns` and also specific per-filetype options with `autocmd Filetype X let b:sandwich_magicchar_f_patterns = ...`, the buffer-local options should probably be used instead of the global ones, but currently the buffer-local options are never used.