### PR TITLE
Use string comparison instead of pattern matching when filtering by filetype filter

### DIFF
--- a/autoload/operator/sandwich/operator.vim
+++ b/autoload/operator/sandwich/operator.vim
@@ -693,7 +693,7 @@ function! s:has_filetype(candidate) abort "{{{
     if filetypes == []
       let filter = 'v:val ==# "all" || v:val ==# ""'
     else
-      let filter = 'v:val ==# "all" || (v:val !=# "" && match(filetypes, v:val) > -1)'
+      let filter = 'v:val ==# "all" || index(filetypes, v:val) > -1'
     endif
     return filter(copy(a:candidate['filetype']), filter) != []
   endif

--- a/autoload/textobj/sandwich/recipes.vim
+++ b/autoload/textobj/sandwich/recipes.vim
@@ -131,7 +131,7 @@ function! s:has_filetype(candidate) abort "{{{
     if filetypes == []
       let filter = 'v:val ==# "all" || v:val ==# ""'
     else
-      let filter = 'v:val ==# "all" || (v:val !=# "" && match(filetypes, v:val) > -1)'
+      let filter = 'v:val ==# "all" || index(filetypes, v:val) > -1'
     endif
     return filter(copy(a:candidate['filetype']), filter) != []
   endif


### PR DESCRIPTION
### Problem

Recipe filtration by a filetype filter is done with pattern matching, instead of string comparison. Which may cause an unexpected behavior.

For expamle, a recipe whose filetype filter is `['java']` is valid in a buffer whose filetype is `javascript`.


### To reproduce

1. Write this in `/tmp/vimrc`:

    ```vim
    call delete('/tmp/vim-sandwich', 'rf')
    call system('git clone https://github.com/machakann/vim-sandwich.git /tmp/vim-sandwich')
    set runtimepath^=/tmp/vim-sandwich
    ```

1. Run `vim -Nu /tmp/vimrc`.

1. Source this script:

    ```vim
    let g:sandwich#recipes = []
    let g:operator#sandwich#recipes = [
          \   {'buns': ['(', ')'], 'filetype': ['java']},
          \ ]
    new
    set filetype=javascript
    call setline('.', 'foo')
    normal 0saiw(
    ```

    The buffer contains this text:

    ```
    (foo)
    ```


### Expected behavior

The buffer contains this text:

```
(foo(
```


### Environment

- vim-sandwich https://github.com/machakann/vim-sandwich/commit/badf78aa821aae8d192cb6da4cc2c095bed15482
- Vim 8.2.3391
- macOS 10.15.7


### Solution

Filter with string comparison instead of pattern matching.