### PR TITLE
fix: don't override existing highlight w/ default

### DIFF
--- a/autoload/operator/sandwich.vim
+++ b/autoload/operator/sandwich.vim
@@ -21,15 +21,15 @@ let s:operator = ''
 "}}}
 " highlight {{{
 function! s:default_highlight() abort
-  highlight! default link OperatorSandwichBuns   IncSearch
-  highlight! default link OperatorSandwichAdd    DiffAdd
-  highlight! default link OperatorSandwichDelete DiffDelete
+  highlight default link OperatorSandwichBuns   IncSearch
+  highlight default link OperatorSandwichAdd    DiffAdd
+  highlight default link OperatorSandwichDelete DiffDelete
 
   if hlexists('OperatorSandwichStuff')
-    highlight! default link OperatorSandwichChange OperatorSandwichStuff
+    highlight default link OperatorSandwichChange OperatorSandwichStuff
   else
     " obsolete
-    highlight! default link OperatorSandwichChange DiffChange
+    highlight default link OperatorSandwichChange DiffChange
   endif
 endfunction
 call s:default_highlight()


### PR DESCRIPTION
`highlight! default` overrides the existing highlight in order to set a default link. So any highlight group that exists before will be wiped over.

To fix this I have changed `highlight! default` to `highlight default`, which only sets the highlight group if it wasn't already defined.