### PR TITLE
Use :let to restore indenkeys

### DIFF
--- a/autoload/operator/sandwich/act.vim
+++ b/autoload/operator/sandwich/act.vim
@@ -387,7 +387,7 @@ endfunction
 function! s:restore_indent(indentopt) abort  "{{{
   " restore indentkeys first
   if a:indentopt.indentkeys.restore
-    execute printf('setlocal %s=%s', a:indentopt.indentkeys.name, a:indentopt.indentkeys.value)
+    let &l:{a:indentopt.indentkeys.name} = a:indentopt.indentkeys.value
   endif
 
   " restore autoindent options


### PR DESCRIPTION
[VimTeX's indentkeys contain space](https://github.com/lervag/vimtex/blob/754bf6c97272e9bf479057b44cc968c4dad34753/indent/tex.vim#L23), so `:set`-ing will fail unless the value is escaped. Use `:let` to avoid that.