### PR TITLE
Escape when restoring indentkyes

### DIFF
--- a/autoload/operator/sandwich/act.vim
+++ b/autoload/operator/sandwich/act.vim
@@ -387,7 +387,7 @@ endfunction
 function! s:restore_indent(indentopt) abort  "{{{
   " restore indentkeys first
   if a:indentopt.indentkeys.restore
-    execute printf('setlocal %s=%s', a:indentopt.indentkeys.name, a:indentopt.indentkeys.value)
+    execute printf('setlocal %s=%s', a:indentopt.indentkeys.name, escape(a:indentopt.indentkeys.value, ' \'))
   endif
 
   " restore autoindent options


### PR DESCRIPTION
[VimTeX's indentkeys contain space](https://github.com/lervag/vimtex/blob/754bf6c97272e9bf479057b44cc968c4dad34753/indent/tex.vim#L23), so it should be escaped.