### PR TITLE
Add vim-surround insert mappings to keymap/surround.vim

### DIFF
--- a/macros/sandwich/keymap/surround.vim
+++ b/macros/sandwich/keymap/surround.vim
@@ -198,3 +198,278 @@ let g:sandwich#recipes = [
       \     'input': ['I'],
       \   },
       \ ]
+
+" insert mappings from vim-surround
+function! s:fixindent(str,spc)
+  let str = substitute(a:str,'\t',repeat(' ',&sw),'g')
+  let spc = substitute(a:spc,'\t',repeat(' ',&sw),'g')
+  let str = substitute(str,'\(\n\|\%^\).\@=','\1'.spc,'g')
+  if ! &et
+    let str = substitute(str,'\s\{'.&ts.'\}',"\t",'g')
+  endif
+  return str
+endfunction
+
+function! s:wrap(string,char,type,removed,special)
+  let keeper = a:string
+  let newchar = a:char
+  let s:input = ""
+  let type = a:type
+  let linemode = type ==# 'V' ? 1 : 0
+  let before = ""
+  let after  = ""
+  if type ==# "V"
+    let initspaces = matchstr(keeper,'\%^\s*')
+  else
+    let initspaces = matchstr(getline('.'),'\%^\s*')
+  endif
+  let pairs = "b()B{}r[]a<>"
+  let extraspace = ""
+  if newchar =~ '^ '
+    let newchar = strpart(newchar,1)
+    let extraspace = ' '
+  endif
+  let idx = stridx(pairs,newchar)
+  if newchar == ' '
+    let before = ''
+    let after  = ''
+  elseif exists("b:surround_".char2nr(newchar))
+    let all    = s:process(b:surround_{char2nr(newchar)})
+    let before = s:extractbefore(all)
+    let after  =  s:extractafter(all)
+  elseif exists("g:surround_".char2nr(newchar))
+    let all    = s:process(g:surround_{char2nr(newchar)})
+    let before = s:extractbefore(all)
+    let after  =  s:extractafter(all)
+  elseif newchar ==# "p"
+    let before = "\n"
+    let after  = "\n\n"
+  elseif newchar ==# 's'
+    let before = ' '
+    let after  = ''
+  elseif newchar ==# ':'
+    let before = ':'
+    let after = ''
+  elseif newchar =~# "[tT\<C-T><]"
+    let dounmapp = 0
+    let dounmapb = 0
+    if !maparg(">","c")
+      let dounmapb = 1
+      " Hide from AsNeeded
+      exe "cn"."oremap > ><CR>"
+    endif
+    let default = ""
+    if newchar ==# "T"
+      if !exists("s:lastdel")
+        let s:lastdel = ""
+      endif
+      let default = matchstr(s:lastdel,'<\zs.\{-\}\ze>')
+    endif
+    let tag = input("<",default)
+    if dounmapb
+      silent! cunmap >
+    endif
+    let s:input = tag
+    if tag != ""
+      let keepAttributes = ( match(tag, ">$") == -1 )
+      let tag = substitute(tag,'>*$','','')
+      let attributes = ""
+      if keepAttributes
+        let attributes = matchstr(a:removed, '<[^ \t\n]\+\zs\_.\{-\}\ze>')
+      endif
+      let s:input = tag . '>'
+      if tag =~ '/$'
+        let tag = substitute(tag, '/$', '', '')
+        let before = '<'.tag.attributes.' />'
+        let after = ''
+      else
+        let before = '<'.tag.attributes.'>'
+        let after  = '</'.substitute(tag,' .*','','').'>'
+      endif
+      if newchar == "\<C-T>"
+        if type ==# "v" || type ==# "V"
+          let before .= "\n\t"
+        endif
+        if type ==# "v"
+          let after  = "\n". after
+        endif
+      endif
+    endif
+  elseif newchar ==# 'l' || newchar == '\'
+    " LaTeX
+    let env = input('\begin{')
+    if env != ""
+      let s:input = env."\<CR>"
+      let env = '{' . env
+      let env .= s:closematch(env)
+      echo '\begin'.env
+      let before = '\begin'.env
+      let after  = '\end'.matchstr(env,'[^}]*').'}'
+    endif
+  elseif newchar ==# 'f' || newchar ==# 'F'
+    let fnc = input('function: ')
+    if fnc != ""
+      let s:input = fnc."\<CR>"
+      let before = substitute(fnc,'($','','').'('
+      let after  = ')'
+      if newchar ==# 'F'
+        let before .= ' '
+        let after = ' ' . after
+      endif
+    endif
+  elseif newchar ==# "\<C-F>"
+    let fnc = input('function: ')
+    let s:input = fnc."\<CR>"
+    let before = '('.fnc.' '
+    let after = ')'
+  elseif idx >= 0
+    let spc = (idx % 3) == 1 ? " " : ""
+    let idx = idx / 3 * 3
+    let before = strpart(pairs,idx+1,1) . spc
+    let after  = spc . strpart(pairs,idx+2,1)
+  elseif newchar == "\<C-[>" || newchar == "\<C-]>"
+    let before = "{\n\t"
+    let after  = "\n}"
+  elseif newchar !~ '\a'
+    let before = newchar
+    let after  = newchar
+  else
+    let before = ''
+    let after  = ''
+  endif
+  let after  = substitute(after ,'\n','\n'.initspaces,'g')
+  if type ==# 'V' || (a:special && type ==# "v")
+    let before = substitute(before,' \+$','','')
+    let after  = substitute(after ,'^ \+','','')
+    if after !~ '^\n'
+      let after  = initspaces.after
+    endif
+    if keeper !~ '\n$' && after !~ '^\n'
+      let keeper .= "\n"
+    elseif keeper =~ '\n$' && after =~ '^\n'
+      let after = strpart(after,1)
+    endif
+    if keeper !~ '^\n' && before !~ '\n\s*$'
+      let before .= "\n"
+      if a:special
+        let before .= "\t"
+      endif
+    elseif keeper =~ '^\n' && before =~ '\n\s*$'
+      let keeper = strcharpart(keeper,1)
+    endif
+    if type ==# 'V' && keeper =~ '\n\s*\n$'
+      let keeper = strcharpart(keeper,0,strchars(keeper) - 1)
+    endif
+  endif
+  if type ==# 'V'
+    let before = initspaces.before
+  endif
+  if before =~ '\n\s*\%$'
+    if type ==# 'v'
+      let keeper = initspaces.keeper
+    endif
+    let padding = matchstr(before,'\n\zs\s\+\%$')
+    let before  = substitute(before,'\n\s\+\%$','\n','')
+    let keeper = s:fixindent(keeper,padding)
+  endif
+  if type ==# 'V'
+    let keeper = before.keeper.after
+  elseif type =~ "^\<C-V>"
+    " Really we should be iterating over the buffer
+    let repl = substitute(before,'[\\~]','\\&','g').'\1'.substitute(after,'[\\~]','\\&','g')
+    let repl = substitute(repl,'\n',' ','g')
+    let keeper = substitute(keeper."\n",'\(.\{-\}\)\(\n\)',repl.'\n','g')
+    let keeper = substitute(keeper,'\n\%$','','')
+  else
+    let keeper = before.extraspace.keeper.extraspace.after
+  endif
+  return keeper
+endfunction
+
+function! s:wrapreg(reg,char,removed,special)
+  let orig = getreg(a:reg)
+  let type = substitute(getregtype(a:reg),'\d\+$','','')
+  let new = s:wrap(orig,a:char,type,a:removed,a:special)
+  call setreg(a:reg,new,type)
+endfunction
+
+function! s:getchar()
+  let c = getchar()
+  if c =~ '^\d\+$'
+    let c = nr2char(c)
+  endif
+  return c
+endfunction
+
+function! s:inputreplacement()
+  let c = s:getchar()
+  if c == " "
+    let c .= s:getchar()
+  endif
+  if c =~ "\<Esc>" || c =~ "\<C-C>"
+    return ""
+  else
+    return c
+  endif
+endfunction
+
+function! s:insert(...)
+  " Optional argument causes the result to appear on 3 lines, not 1
+  let linemode = a:0 ? a:1 : 0
+  let char = s:inputreplacement()
+  while char == "\<CR>" || char == "\<C-S>"
+    " TODO: use total count for additional blank lines
+    let linemode += 1
+    let char = s:inputreplacement()
+  endwhile
+  if char == ""
+    return ""
+  endif
+  let cb_save = &clipboard
+  set clipboard-=unnamed clipboard-=unnamedplus
+  let reg_save = @@
+  call setreg('"',"\032",'v')
+  call s:wrapreg('"',char,"",linemode)
+  " If line mode is used and the surrounding consists solely of a suffix,
+  " remove the initial newline.  This fits a use case of mine but is a
+  " little inconsistent.  Is there anyone that would prefer the simpler
+  " behavior of just inserting the newline?
+  if linemode && match(getreg('"'),'^\n\s*\zs.*') == 0
+    call setreg('"',matchstr(getreg('"'),'^\n\s*\zs.*'),getregtype('"'))
+  endif
+  " This can be used to append a placeholder to the end
+  if exists("g:surround_insert_tail")
+    call setreg('"',g:surround_insert_tail,"a".getregtype('"'))
+  endif
+  if &ve != 'all' && col('.') >= col('$')
+    if &ve == 'insert'
+      let extra_cols = virtcol('.') - virtcol('$')
+      if extra_cols > 0
+        let [regval,regtype] = [getreg('"',1,1),getregtype('"')]
+        call setreg('"',join(map(range(extra_cols),'" "'),''),'v')
+        norm! ""p
+        call setreg('"',regval,regtype)
+      endif
+    endif
+    norm! ""p
+  else
+    norm! ""P
+  endif
+  if linemode
+    call s:reindent()
+  endif
+  norm! `]
+  call search("\032",'bW')
+  let @@ = reg_save
+  let &clipboard = cb_save
+  return "\<Del>"
+endfunction
+
+inoremap <silent> <Plug>Isurround <C-R>=<SID>insert()<CR>
+inoremap <silent> <Plug>ISurround <C-R>=<SID>insert(1)<CR>
+
+if !hasmapto("<Plug>Isurround","i") && "" == mapcheck("<C-S>","i")
+  imap <C-S> <Plug>Isurround
+endif
+imap <C-G>s <Plug>Isurround
+imap <C-G>S <Plug>ISurround


### PR DESCRIPTION
Hello, thanks for all the effort on this plugin. I really enjoy using the vim-surround mappings specifically so thanks for thinking of us converts. This was the missing ingredient in the _sandwich_ for me.

If merged, a few sentences could be added to the [wiki page](https://github.com/machakann/vim-sandwich/wiki/Introduce-vim-surround-keymappings) inspired by the [vim-surround helptext](https://github.com/tpope/vim-surround/blob/master/doc/surround.txt#L82-L89)