### PR TITLE
Adapt to local virtualedit

### DIFF
--- a/autoload/operator/sandwich/act.vim
+++ b/autoload/operator/sandwich/act.vim
@@ -189,10 +189,10 @@ function! s:act.replace_pair(buns, stuff, undojoin, modified) dict abort "{{{
   let opt     = self.opt
 
   if s:lib.is_valid_4pos(target) && s:lib.is_ahead(target.head2, target.tail1)
-    set virtualedit=
+    setlocal virtualedit=
     let next_head = s:lib.get_right_pos(target.tail1)
     let next_tail = s:lib.get_left_pos(target.head2)
-    set virtualedit=onemore
+    setlocal virtualedit=onemore
 
     let reg = ['"', getreg('"'), getregtype('"')]
     let deletion = ['', '']

--- a/autoload/operator/sandwich/operator.vim
+++ b/autoload/operator/sandwich/operator.vim
@@ -149,8 +149,8 @@ endfunction
 function! s:operator.split(region) dict abort  "{{{
   let reg  = ['"', getreg('"'), getregtype('"')]
   let view = winsaveview()
-  let virtualedit = &virtualedit
-  let &virtualedit = 'all'
+  let virtualedit = &l:virtualedit
+  let &l:virtualedit = 'all'
   try
     if self.blockwidth == 0
       " The case for blockwise motions in operator-pending mode
@@ -193,7 +193,7 @@ function! s:operator.split(region) dict abort  "{{{
   finally
     call call('setreg', reg)
     call winrestview(view)
-    let &virtualedit = virtualedit
+    let &l:virtualedit = virtualedit
   endtry
   return region_list
 endfunction
@@ -776,7 +776,7 @@ endfunction
 function! s:shift_options(kind, mode) abort "{{{
   """ save options
   let options = {}
-  let options.virtualedit = &virtualedit
+  let options.virtualedit = &l:virtualedit
   let options.whichwrap   = &whichwrap
   let options.cpoptions   = &cpoptions
   let options.formatoptions = &formatoptions
@@ -804,7 +804,7 @@ function! s:shift_options(kind, mode) abort "{{{
   endif
 
   """ shift options
-  set virtualedit=onemore
+  setlocal virtualedit=onemore
   set whichwrap=h,l
   set cpoptions-=l
   set cpoptions-=\
@@ -824,7 +824,7 @@ function! s:restore_options(kind, mode, options) abort "{{{
     let &t_ve = a:options.cursor
   endif
 
-  let &virtualedit = a:options.virtualedit
+  let &l:virtualedit = a:options.virtualedit
   let &whichwrap   = a:options.whichwrap
   let &cpoptions   = a:options.cpoptions
   let &l:formatoptions = a:options.formatoptions

--- a/autoload/textobj/sandwich.vim
+++ b/autoload/textobj/sandwich.vim
@@ -55,8 +55,8 @@ function! textobj#sandwich#select() abort  "{{{
   let textobj = g:textobj#sandwich#object
   call textobj.initialize()
   let stimeoutlen = max([0, s:get_textobj_option('stimeoutlen', 500)])
-  let [virtualedit, whichwrap]   = [&virtualedit, &whichwrap]
-  let [&virtualedit, &whichwrap] = ['onemore', 'h,l']
+  let [virtualedit, whichwrap]   = [&l:virtualedit, &whichwrap]
+  let [&l:virtualedit, &whichwrap] = ['onemore', 'h,l']
   try
     let candidates = textobj.list(stimeoutlen)
     let elected = textobj.elect(candidates)
@@ -68,7 +68,7 @@ function! textobj#sandwich#select() abort  "{{{
     if !textobj.done
       call winrestview(view)
     endif
-    let [&virtualedit, &whichwrap] = [virtualedit, whichwrap]
+    let [&l:virtualedit, &whichwrap] = [virtualedit, whichwrap]
   endtry
 
   let g:textobj#sandwich#object = textobj " This is required in case that textobj-sandwich call textobj-sandwich itself in its recipe.


### PR DESCRIPTION
Problem:
virtualedit can be window-local since Vim 8.2.3227 and 8.2.3280. So, if sandwich is invoked in a window with local virtualedit set, the option restoration logic globally applies that window's local virtualedit to other windows (see :h global-local).

Solution:
Use setlocal and &l:.